### PR TITLE
Fix for client crash

### DIFF
--- a/lib/sensu/transport/snssqs.rb
+++ b/lib/sensu/transport/snssqs.rb
@@ -53,6 +53,7 @@ module Sensu
       end
 
       def statsd_time(stat)
+        return if @statsd.nil?
         # always measure + run the block, but only if @statsd is set
         # do we actually report it.
         start = Time.now


### PR DESCRIPTION
if you set statsd_addr to "" the sensu-client crashes, this fix seems to help.